### PR TITLE
Update .cabal file

### DIFF
--- a/partial-isomorphisms.cabal
+++ b/partial-isomorphisms.cabal
@@ -24,7 +24,7 @@ Maintainer:          Tillmann Rendel <rendel@informatik.uni-marburg.de>
 Category:            Control
 Build-type:          Simple
 -- Extra-source-files:
-Cabal-version:       >=1.6
+Cabal-version:       >=1.10
 
 source-repository head
   type: git
@@ -39,7 +39,9 @@ Library
                     Control.Isomorphism.Partial.TH
                     Control.Isomorphism.Partial.Unsafe
 
-  Build-depends:    base >= 3 && < 5, template-haskell
+  default-language: Haskell2010
+  other-extensions: TemplateHaskell, KindSignatures 
+  Build-depends:    base >= 3 && < 5, template-haskell >= 2.11
 
   ghc-options:     -Wall
 


### PR DESCRIPTION
This updates the `.cabal` file by declaring requirements more accurately, which prevents the cabal solver from selecting unsound install-plans.